### PR TITLE
Disallow sending empty message

### DIFF
--- a/pica-client/chatwindow.cpp
+++ b/pica-client/chatwindow.cpp
@@ -264,21 +264,35 @@ void ChatWindow::msg_informational(QString text)
   chatw->moveCursor(QTextCursor::End, QTextCursor::KeepAnchor);
 }
 
+bool ChatWindow::isEmptyMessage(const QString &msg) const
+{
+    int size = msg.size();
+    for (int i = 0; i < size; ++i) {
+        if (!msg.at(i).isSpace()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 void ChatWindow::send_message()
 {
-    put_message(sendtextw->toPlainText(), Accounts::GetCurrentAccount().id, true);
-    hist.Add(peer_id_, sendtextw->toPlainText(), true);
+    QString message = sendtextw->toPlainText();
+    if (!isEmptyMessage(message)) {
+        put_message(message, Accounts::GetCurrentAccount().id, true);
+        hist.Add(peer_id_, message, true);
 
-    if (!hist.isOK())
-    {
-        QMessageBox mbx;
-        mbx.setText(hist.GetLastError());
-        mbx.exec();
+        if (!hist.isOK())
+        {
+            QMessageBox mbx;
+            mbx.setText(hist.GetLastError());
+            mbx.exec();
+        }
+
+        emit msg_input(message, this);
+
+        sendtextw->clear();
     }
-
-    emit msg_input(sendtextw->toPlainText(), this);
-
-    sendtextw->clear();
 }
 
 void ChatWindow::closeEvent(QCloseEvent *e)

--- a/pica-client/chatwindow.h
+++ b/pica-client/chatwindow.h
@@ -60,6 +60,7 @@ private:
     QPushButton *btAddCtBlacklist;
     QLabel *lbAddCtQuestion;
 
+    bool isEmptyMessage(const QString &msg) const;
     void put_message(QString msg, QByteArray id, bool is_me);
     int draw_message(QString msg, QString nickname, QString datetime, QString color, bool is_delivered);
     void print_history(QList<History::HistoryRecord> H);


### PR DESCRIPTION
Fix this bug:
![pica-pica](https://cloud.githubusercontent.com/assets/232116/3898055/badd1d1c-2267-11e4-9f9f-ea0c536cafa2.png)

Test **isEmptyMessage()** func:

| QString Message | Return Value |
| --- | --- |
| NULL | true |
| "" (Empty string) | true |
| " " (Space char) | true |
| " a" (Space with symbol) | false |
| "\n" (Break Line) | true |
| "\n " (Break Line and space) | true |
| "\n \t" (Break Line and space and tab) | true |
| "\n \ta" (Separators symbols and 'a') | false |
